### PR TITLE
DLL Ejection

### DIFF
--- a/osu!Lyrics/Program.cs
+++ b/osu!Lyrics/Program.cs
@@ -29,6 +29,7 @@ namespace osu_Lyrics
                     Application.Run(new CanvasForm());
 
                     Osu.UnhookKeyboard();
+                    Osu.ShutdownMessageServer();
                 }
             }
         }


### PR DESCRIPTION
* 인젝션 후 `GetExitCodeThread`로 `LoadLibrary`의 결과값 받아오기 성공
* `FreeLibrary` 호출로 `DLL_PROCESS_DETACH` 신호 발생 확인

남은 작업은...
* [ ] Core.cpp -> Stop으로 NamedPipe::Stop()이 무한 대기하는 문제 해결